### PR TITLE
Add cross platform command injection demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Command Injection Demo
+
+Dieses kleine Projekt demonstriert eine typische OWASP Top 10 Schwachstelle: Command Injection.
+Es stehen zwei Varianten zur Verf\u00fcgung: eine verwundbare und eine sichere Implementierung.
+
+## Voraussetzungen
+* Python 3
+* [Flask](https://flask.palletsprojects.com/) (`pip install flask`)
+
+## Starten der Anwendung
+```bash
+python app.py
+```
+Die Anwendung lauscht dann auf `http://localhost:5000`.
+
+## Bedienung
+1. Rufen Sie im Browser `http://localhost:5000` auf.
+2. W\u00e4hlen Sie oben Ihr Betriebssystem (Linux/macOS oder Windows).
+3. W\u00e4hlen Sie per Radiobutton die verwundbare oder sichere Version.
+4. Geben Sie eine IP-Adresse ein und klicken Sie auf **Ping senden**.
+
+### Verwundbare Version ausnutzen
+* **Linux/macOS:** `127.0.0.1; ls`
+* **Windows:** `127.0.0.1 & dir`
+
+Die Ausgabe des zusätzlichen Kommandos wird im Textfeld angezeigt.
+
+### Sichere Version
+Hier wird die Eingabe validiert und ohne Shell ausgef\u00fchrt. Der Versuch, weitere Befehle anzuh\u00e4ngen, f\u00fchrt zu einer Fehlermeldung.
+
+## Funktionsweise
+Die verwundbare Version f\u00fchrt das Kommando
+```
+ping -c 1 <ip>  # Linux/macOS
+ping -n 1 <ip>  # Windows
+```
+direkt in der Shell aus. \nDadurch k\u00f6nnen angeh\u00e4ngte Befehle ausgef\u00fchrt werden.
+
+Die sichere Variante pr\u00fcft die IP-Adresse mittels Regex
+und \u00fcbergibt das Kommando ohne Shell an `subprocess.run()`.
+

--- a/app.py
+++ b/app.py
@@ -9,22 +9,35 @@ app = Flask(__name__, static_folder='static')
 def index():
     return send_from_directory('static', 'index.html')
 
+def _ping_command(ip: str, os_name: str) -> str:
+    """Create the ping command for the given OS."""
+    if os_name.lower() == "windows":
+        flag = "-n 1"
+    else:
+        flag = "-c 1"
+    return f"ping {flag} {ip}"
+
+
 @app.route('/vulnerable/ping')
 def vulnerable_ping():
     ip = request.args.get('ip')
+    os_name = request.args.get('os', 'linux')
     # Verwundbar: direkte Shell-Ausführung
-    result = os.popen(f"ping -c 1 {ip}").read()
+    cmd = _ping_command(ip, os_name)
+    result = os.popen(cmd).read()
     return result
 
 @app.route('/secure/ping')
 def secure_ping():
     ip = request.args.get('ip')
+    os_name = request.args.get('os', 'linux')
     # Nur IPv4-Adressen erlauben
     if not re.match(r'^\d{1,3}(\.\d{1,3}){3}$', ip):
         return "Ungültige IP-Adresse", 400
     try:
+        cmd = _ping_command(ip, os_name).split()
         result = subprocess.run(
-            ["ping", "-c", "1", ip],
+            cmd,
             capture_output=True,
             text=True,
             timeout=5

--- a/static/index.html
+++ b/static/index.html
@@ -10,19 +10,28 @@
   <div class="container">
     <h1>Secure Coding – Command Injection Demo</h1>
 
-    <div class="toggle">
-      <label><input type="radio" name="mode" value="vulnerable" checked> Verwundbare Version</label>
-      <label><input type="radio" name="mode" value="secure"> Sichere Version</label>
-    </div>
+  <div class="toggle">
+    <label><input type="radio" name="mode" value="vulnerable" checked> Verwundbare Version</label>
+    <label><input type="radio" name="mode" value="secure"> Sichere Version</label>
+  </div>
 
-    <input type="text" id="ip" placeholder="z. B. 127.0.0.1 oder 127.0.0.1; ls" />
+  <div class="os-select">
+    <label>Betriebssystem:
+      <select id="os">
+        <option value="linux">Linux/macOS</option>
+        <option value="windows">Windows</option>
+      </select>
+    </label>
+  </div>
+
+  <input type="text" id="ip" placeholder="z. B. 127.0.0.1 oder 127.0.0.1; ls/dir" />
     <button onclick="ping()">Ping senden</button>
 
     <pre id="output"></pre>
 
     <h2>📘 Erklärung</h2>
-    <p><strong>Verwundbare Version:</strong> Der Server führt das Kommando <code>ping -c 1 &lt;ip&gt;</code> direkt aus – ohne Validierung. Ein Angreifer könnte so zusätzliche Shell-Befehle ausführen (z. B. <code>; ls</code>).</p>
-    <p><strong>Sichere Version:</strong> Die Eingabe wird auf gültige IP-Adressen geprüft, und das Kommando wird über <code>subprocess.run()</code> mit Argumenten übergeben – ohne Shell-Zugriff.</p>
+    <p><strong>Verwundbare Version:</strong> Der Server führt ein <code>ping</code>-Kommando direkt in der Shell aus. Je nach gewähltem Betriebssystem lautet es <code>ping -c 1 &lt;ip&gt;</code> (Linux/macOS) oder <code>ping -n 1 &lt;ip&gt;</code> (Windows). Ohne Validierung kann ein Angreifer weitere Befehle anhängen, z. B. <code>; ls</code> bzw. <code>&amp; dir</code>.</p>
+    <p><strong>Sichere Version:</strong> Die Eingabe wird auf gültige IP-Adressen geprüft und das Kommando ohne Shell mit <code>subprocess.run()</code> ausgeführt. Dadurch wird eine Befehlsinjektion verhindert.</p>
   </div>
   <script src="script.js"></script>
 </body>

--- a/static/script.js
+++ b/static/script.js
@@ -2,11 +2,12 @@ function ping() {
   const ip = document.getElementById('ip').value;
   const output = document.getElementById('output');
   const mode = document.querySelector('input[name="mode"]:checked').value;
+  const osName = document.getElementById('os').value;
   const endpoint = mode === 'vulnerable' ? '/vulnerable/ping' : '/secure/ping';
 
   output.textContent = 'Sende Anfrage...';
 
-  fetch(`${endpoint}?ip=${encodeURIComponent(ip)}`)
+  fetch(`${endpoint}?ip=${encodeURIComponent(ip)}&os=${encodeURIComponent(osName)}`)
     .then(res => res.text())
     .then(data => {
       output.textContent = data;


### PR DESCRIPTION
## Summary
- add README with instructions for vulnerable and secure versions
- support Windows and Linux with OS selector in the UI
- pass OS choice to backend and adjust ping flags

## Testing
- `python3 -m py_compile app.py`
- `pip install flask`
- `python3 app.py` (server started)